### PR TITLE
Fixes #53 - adding Observer.UnitTests

### DIFF
--- a/Vote.Monitor.sln
+++ b/Vote.Monitor.sln
@@ -42,6 +42,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Vote.Monitor.Api.Integratio
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Vote.Monitor.Api.Feature.PollingStation.UnitTests", "tests\Vote.Monitor.Api.Feature.PollingStation.UnitTests\Vote.Monitor.Api.Feature.PollingStation.UnitTests.csproj", "{272F6196-AB33-461D-8E12-FB1260D6D4C0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Vote.Monitor.Api.Feature.Observer.UnitTests", "tests\Vote.Monitor.Api.Feature.Observer.UnitTests\Vote.Monitor.Api.Feature.Observer.UnitTests.csproj", "{D65C2019-13CC-472B-8AEB-CEDAD542C157}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -104,6 +106,10 @@ Global
 		{272F6196-AB33-461D-8E12-FB1260D6D4C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{272F6196-AB33-461D-8E12-FB1260D6D4C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{272F6196-AB33-461D-8E12-FB1260D6D4C0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D65C2019-13CC-472B-8AEB-CEDAD542C157}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D65C2019-13CC-472B-8AEB-CEDAD542C157}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D65C2019-13CC-472B-8AEB-CEDAD542C157}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D65C2019-13CC-472B-8AEB-CEDAD542C157}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -123,6 +129,7 @@ Global
 		{9D19DBEA-7447-4C46-AAFD-E25D64784469} = {17945B3C-5A4C-4279-8022-65ABC606A510}
 		{91738C86-9A9D-44D9-86C0-67C7CF43FB0D} = {3441EE1D-E3C6-45BE-A020-553816015081}
 		{272F6196-AB33-461D-8E12-FB1260D6D4C0} = {3441EE1D-E3C6-45BE-A020-553816015081}
+		{D65C2019-13CC-472B-8AEB-CEDAD542C157} = {3441EE1D-E3C6-45BE-A020-553816015081}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {50C20C9F-F2AF-45D8-994A-06661772B31C}

--- a/tests/Vote.Monitor.Api.Feature.Observer.UnitTests/GlobalUsings.cs
+++ b/tests/Vote.Monitor.Api.Feature.Observer.UnitTests/GlobalUsings.cs
@@ -1,0 +1,6 @@
+﻿global using Xunit;
+
+global using ObserverAggregate = Vote.Monitor.Domain.Entities.ApplicationUserAggregate.Observer;
+global using FluentAssertions;
+global using Vote.Monitor.Api.Feature.Observer.UnitTests.Specifications;
+global using Vote.Monitor.Domain.Entities.ApplicationUserAggregate;

--- a/tests/Vote.Monitor.Api.Feature.Observer.UnitTests/GlobalUsings.cs
+++ b/tests/Vote.Monitor.Api.Feature.Observer.UnitTests/GlobalUsings.cs
@@ -4,3 +4,4 @@ global using ObserverAggregate = Vote.Monitor.Domain.Entities.ApplicationUserAgg
 global using FluentAssertions;
 global using Vote.Monitor.Api.Feature.Observer.UnitTests.Specifications;
 global using Vote.Monitor.Domain.Entities.ApplicationUserAggregate;
+global using AutoBogus;

--- a/tests/Vote.Monitor.Api.Feature.Observer.UnitTests/Specifications/GetObserverByLoginSpecificationTests.cs
+++ b/tests/Vote.Monitor.Api.Feature.Observer.UnitTests/Specifications/GetObserverByLoginSpecificationTests.cs
@@ -1,0 +1,26 @@
+﻿namespace Vote.Monitor.Api.Feature.Observer.Specifications;
+
+public class GetObserverByLoginSpecificationTests
+{
+    [Fact]
+    public void GetObserverByLoginSpecificationTests_AppliesCorrectFilters()
+    {
+        // Arrange
+        var observer = new ObserverAggregateFaker().Generate();
+
+        var testCollection = new ObserverAggregateFaker()
+            .Generate(500)
+            .Union(new[] { observer })
+            .Union(new ObserverAggregateFaker().Generate(500))
+            .ToList();
+
+        var spec = new GetObserverByLoginSpecification(observer.Login);
+
+        // Act
+        var result = spec.Evaluate(testCollection).ToList();
+
+        //// Assert
+        result.Should().HaveCount(1); // Expecting only one item in the result
+        result.Should().Contain(observer);
+    }
+}

--- a/tests/Vote.Monitor.Api.Feature.Observer.UnitTests/Specifications/ListObserversSpecificationTests.cs
+++ b/tests/Vote.Monitor.Api.Feature.Observer.UnitTests/Specifications/ListObserversSpecificationTests.cs
@@ -1,0 +1,82 @@
+﻿
+
+namespace Vote.Monitor.Api.Feature.Observer.Specifications;
+
+public class ListObserversSpecificationTests
+{
+    private const string DefaultName = "name";
+    private readonly UserStatus DefaultStatus = UserStatus.Active;
+
+    [Fact]
+    public void ListObserversSpecification_AppliesCorrectFilters()
+    {
+        // Arrange
+        var observer1 = new ObserverAggregateFaker(status: DefaultStatus).Generate();
+        var observer2 = new ObserverAggregateFaker(status: DefaultStatus).Generate();
+
+        var testCollection = Enumerable.Range(1, 100)
+            .Select(status => new ObserverAggregateFaker(status: DefaultStatus).Generate())
+        .Union(new[] { observer1, observer2 })
+        .ToList();
+
+        var spec = new ListObserversSpecification(null, null, 100, 2);
+
+        // Act
+        var result = spec.Evaluate(testCollection).ToList();
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.Should().Contain(observer1);
+        result.Should().Contain(observer2);
+    }
+
+    [Fact]
+    public void ListObserversSpecification_AppliesCorrectFilters_WhenNameFilterApplied()
+    {
+        // Arrange
+        var observer1 = new ObserverAggregateFaker(name: DefaultName, status: DefaultStatus).Generate();
+        var observer2 = new ObserverAggregateFaker(name: DefaultName, status: DefaultStatus).Generate();
+
+        var testCollection = Enumerable
+            .Range(1, 100)
+            .Select(statusArg => new ObserverAggregateFaker(name: DefaultName, status: DefaultStatus).Generate())
+            .Union(new[] { observer1, observer2 })
+            .ToList();
+
+        var spec = new ListObserversSpecification(DefaultName, null, 100, 2);
+
+        // Act
+        var result = spec.Evaluate(testCollection).ToList();
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.Should().Contain(observer1);
+        result.Should().Contain(observer2);
+    }
+
+    [Theory]
+    [InlineData("name1")]
+    [InlineData("name2")]
+    public void ListObserversSpecification_AppliesCorrectFilters_WhenPartialFilterApplied(string searchString)
+    {
+        // Arrange
+        var observer1 = new ObserverAggregateFaker(name: searchString, status: DefaultStatus).Generate();
+        var observer2 = new ObserverAggregateFaker(name: searchString, status: DefaultStatus).Generate();
+
+        var testCollection = Enumerable
+            .Range(1, 100)
+            .Select(statusArg => new ObserverAggregateFaker(name: searchString, status: DefaultStatus).Generate())
+            .Union(new[] { observer1, observer2 })
+            .ToList();
+
+        var spec = new ListObserversSpecification(searchString, null, 100, 2);
+
+        // Act
+        var result = spec.Evaluate(testCollection).ToList();
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.Should().Contain(observer1);
+        result.Should().Contain(observer2);
+    }
+}

--- a/tests/Vote.Monitor.Api.Feature.Observer.UnitTests/Specifications/ObserverAggregateFaker.cs
+++ b/tests/Vote.Monitor.Api.Feature.Observer.UnitTests/Specifications/ObserverAggregateFaker.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using AutoBogus;
-using Bogus;
-using Bogus.DataSets;
-using Vote.Monitor.Domain.Entities.ApplicationUserAggregate;
-
-namespace Vote.Monitor.Api.Feature.Observer.UnitTests.Specifications;
+﻿namespace Vote.Monitor.Api.Feature.Observer.UnitTests.Specifications;
 
 public class ObserverAggregateFaker : AutoFaker<ObserverAggregate>
 {

--- a/tests/Vote.Monitor.Api.Feature.Observer.UnitTests/Specifications/ObserverAggregateFaker.cs
+++ b/tests/Vote.Monitor.Api.Feature.Observer.UnitTests/Specifications/ObserverAggregateFaker.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using AutoBogus;
+using Bogus;
+using Bogus.DataSets;
+using Vote.Monitor.Domain.Entities.ApplicationUserAggregate;
+
+namespace Vote.Monitor.Api.Feature.Observer.UnitTests.Specifications;
+
+public class ObserverAggregateFaker : AutoFaker<ObserverAggregate>
+{
+    UserStatus[] statuses = new UserStatus[] { UserStatus.Active, UserStatus.Deactivated };
+    public ObserverAggregateFaker(string? name=null, string? login=null, string? password=null, UserStatus? status=null)
+    {
+        RuleFor(fake => fake.Name, fake => name ?? fake.Name.FirstName());
+        RuleFor(fake => fake.Login, fake => login ?? fake.Internet.Email());
+        RuleFor(fake => fake.Password, fake => password ?? fake.Random.String2(10));
+        RuleFor(fake => fake.Status, fake => status ?? statuses[fake.Random.Int(0, 1)]);
+
+    }
+}

--- a/tests/Vote.Monitor.Api.Feature.Observer.UnitTests/Vote.Monitor.Api.Feature.Observer.UnitTests.csproj
+++ b/tests/Vote.Monitor.Api.Feature.Observer.UnitTests/Vote.Monitor.Api.Feature.Observer.UnitTests.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="AutoBogus" Version="2.13.1" />
+    <PackageReference Include="Bogus" Version="34.0.2" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="FluentValidation" Version="11.8.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="Specifications\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Specifications\" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Vote.Monitor.Domain\Vote.Monitor.Domain.csproj" />
+    <ProjectReference Include="..\..\src\Vote.Monitor.Core\Vote.Monitor.Core.csproj" />
+    <ProjectReference Include="..\..\src\Vote.Monitor.Api.Feature.Observer\Vote.Monitor.Api.Feature.Observer.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes #53 Adding UnitTests for Observer.Specifications by following the tests added in PollingStations.UnitTests. Please let me know if I should continue to also add ValidatorTests and the specifics or constraints I should consider.