### PR TITLE
feat B293: display confirmation modal for unsaved answers

### DIFF
--- a/mobile/app/(app)/(drawer)/(tabs)/more.tsx
+++ b/mobile/app/(app)/(drawer)/(tabs)/more.tsx
@@ -188,6 +188,7 @@ const More = () => {
       )}
       {showWarningModal && (
         <WarningDialog
+          theme="info"
           title={
             isOnline
               ? t("warning_modal.logout_online.title")
@@ -203,7 +204,6 @@ const More = () => {
           cancelBtnText={t("warning_modal.logout_online.cancel")}
           action={logout}
           onCancel={() => setShowWarningModal(false)}
-          actionBtnStyle={{ backgroundColor: "hsl(272, 56%, 45%)" }}
         />
       )}
     </Screen>

--- a/mobile/assets/locales/en/translations.json
+++ b/mobile/assets/locales/en/translations.json
@@ -315,6 +315,14 @@
           "cancel": "Cancel",
           "clear": "Delete"
         }
+      },
+      "unsaved_answer": {
+        "title": "Save changes to question",
+        "description": "You have unsaved changes on this question. Do you want to save your changes before leaving?",
+        "actions": {
+          "cancel": "Discard",
+          "save": "Save changes"
+        }
       }
     },
     "error": "Error while loading question data!"

--- a/mobile/components/WarningDialog.tsx
+++ b/mobile/components/WarningDialog.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from "react";
 import { Typography } from "./Typography";
 import { Dialog } from "./Dialog";
-import { ScrollView, XStack, YStack } from "tamagui";
+import { ScrollView, useTheme, XStack, YStack } from "tamagui";
 import Button from "./Button";
 import { StyleProp, TextStyle } from "react-native";
 
@@ -11,9 +11,9 @@ type WarningDialogProps = {
   actionBtnText: string;
   cancelBtnText: string;
   onCancel: () => void;
-  action: () => void;
-  actionBtnStyle?: object;
+  action?: () => void;
   titleProps?: StyleProp<TextStyle>;
+  theme?: "info" | "danger";
 };
 
 const WarningDialog = ({
@@ -23,9 +23,10 @@ const WarningDialog = ({
   cancelBtnText,
   action,
   onCancel,
-  actionBtnStyle,
   titleProps,
+  theme = "danger",
 }: WarningDialogProps) => {
+  const tamaguiTheme = useTheme();
   return (
     <Dialog
       open
@@ -53,7 +54,10 @@ const WarningDialog = ({
         <XStack gap="$sm" justifyContent="center" alignItems="center">
           <Button
             preset="chromeless"
-            textStyle={{ color: "black", textAlign: "center" }}
+            textStyle={{
+              color: theme === "danger" ? "black" : tamaguiTheme.$purple5?.val,
+              textAlign: "center",
+            }}
             onPress={onCancel}
             height="100%"
           >
@@ -62,12 +66,11 @@ const WarningDialog = ({
 
           {actionBtnText && (
             <Button
-              backgroundColor="$red10"
+              preset={theme === "danger" ? "red" : "default"}
               height="100%"
               flex={1}
               onPress={action}
               textStyle={{ textAlign: "center" }}
-              style={{ ...actionBtnStyle }}
             >
               {actionBtnText}
             </Button>


### PR DESCRIPTION
Figma reference: https://www.figma.com/design/OdPI6l30uEbnYfxMpoulhD/Vote-Monitor-2.0?node-id=6710-38941&t=3Xtu8AkI5K29En2X-4

Display confirmation modal when in form wizard and leaving question while having an unsaved answer.
- When clicking on back wizard control
- When clicking on back icon (header)